### PR TITLE
Match the GIT version tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "php": "~5.5.0|~5.6.0|~7.0.0|~7.1"
   },
   "type": "magento2-module",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "license": [
     "OSL-3.0"
   ],


### PR DESCRIPTION
Or else [Packagist](https://packagist.org/packages/firebear/shapeshift) does not see the 1.0.13 GIT tag as a valid version. #5 
  